### PR TITLE
Fixes missing $gutter declaration in foundation-flex-grid mixin.

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -164,7 +164,9 @@ $-zf-flex-align: (
   align-self: $y;
 }
 
-@mixin foundation-flex-grid {
+@mixin foundation-flex-grid(
+  $gutter: $grid-column-gutter
+) {
   // Row
   .row {
     @include flex-grid-row;


### PR DESCRIPTION
Added a `$gutter: $grid-column-gutter` declaration to the `foundation-flex-grid` mixin to fix #7679.